### PR TITLE
Atualização RDS.

### DIFF
--- a/kubernetes/kubectl/backend/deployment.yaml
+++ b/kubernetes/kubectl/backend/deployment.yaml
@@ -35,7 +35,7 @@ spec:
               memory: "1Gi"
           env:
             - name: DATABASE_HOST
-              value: db-tc-backends2-fiap.cqjmd1nvleyg.us-east-1.rds.amazonaws.com
+              value: db-tc-backends2.ch22s8kum70l.us-east-1.rds.amazonaws.com
             - name: DATABASE_USER
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
Devido a atualização da data do curso da plataforma da AWS Academy ter sido atualizada, foi necessário criar um novo ambiente e substituir os dados de conexão do novo banco.